### PR TITLE
build: generate distro during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
+FROM node:20-alpine AS build
+
+WORKDIR /usr/src/app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run distro
+
 FROM node:20-alpine AS base
 
 WORKDIR /usr/src/app
@@ -5,10 +15,10 @@ WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 
-COPY dist ./dist
-COPY assets ./assets
-COPY resources ./resources
-COPY app ./app
+COPY --from=build /usr/src/app/dist ./dist
+COPY --from=build /usr/src/app/assets ./assets
+COPY --from=build /usr/src/app/resources ./resources
+COPY --from=build /usr/src/app/app ./app
 
 ENV NODE_ENV=production \
     PORT=3000 \


### PR DESCRIPTION
## Summary
- add a build stage to the Dockerfile that installs dev dependencies and runs the distro build
- copy built assets into the runtime stage so the image always contains the distribution

## Testing
- npm run distro

------
https://chatgpt.com/codex/tasks/task_e_68de9214dc48832c8bb2f7a534d556d7