### PR TITLE
Fix Docker build by enabling npm in runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM node:20-alpine AS build
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN corepack enable \
+    && corepack prepare npm@latest --activate \
+    && npm ci
 
 COPY . .
 RUN npm run distro
@@ -13,7 +15,9 @@ FROM node:20-alpine AS base
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN corepack enable \
+    && corepack prepare npm@latest --activate \
+    && npm ci --omit=dev
 
 COPY --from=build /usr/src/app/dist ./dist
 COPY --from=build /usr/src/app/assets ./assets


### PR DESCRIPTION
## Summary
- ensure npm is available in both build and runtime stages by enabling corepack before running npm commands

## Testing
- not run (Docker build tooling not available in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68de933532b0832ca628bdd767cdfc95