### PR TITLE
Fix Docker build by installing npm directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM node:20-alpine AS build
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN corepack enable \
-    && corepack prepare npm@latest --activate \
+RUN npm install -g npm@latest \
     && npm ci
 
 COPY . .
@@ -15,8 +14,7 @@ FROM node:20-alpine AS base
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN corepack enable \
-    && corepack prepare npm@latest --activate \
+RUN npm install -g npm@latest \
     && npm ci --omit=dev
 
 COPY --from=build /usr/src/app/dist ./dist


### PR DESCRIPTION
## Summary
- replace corepack commands in the Dockerfile with a direct npm installation to avoid missing binary errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de9454f3ec832ca893441186a88e50