### PR TITLE
fix: prepare npm via corepack in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:20-alpine AS build
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN npm install -g npm@latest \
+RUN corepack enable \
+    && corepack prepare npm@latest --activate \
     && npm ci
 
 COPY . .
@@ -14,7 +15,8 @@ FROM node:20-alpine AS base
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN npm install -g npm@latest \
+RUN corepack enable \
+    && corepack prepare npm@latest --activate \
     && npm ci --omit=dev
 
 COPY --from=build /usr/src/app/dist ./dist


### PR DESCRIPTION
## Summary
- enable corepack before npm install steps to ensure npm is available during image builds

## Testing
- not run (docker build change)


------
https://chatgpt.com/codex/tasks/task_e_68de9518a76c832c93815be637376e70