### PR TITLE
Fix Docker build by removing corepack dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM node:20-alpine AS build
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN corepack enable \
-    && corepack prepare npm@latest --activate \
+RUN npm install -g npm@latest \
     && npm ci
 
 COPY . .
@@ -15,8 +14,7 @@ FROM node:20-alpine AS base
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN corepack enable \
-    && corepack prepare npm@latest --activate \
+RUN npm install -g npm@latest \
     && npm ci --omit=dev
 
 COPY --from=build /usr/src/app/dist ./dist


### PR DESCRIPTION
## Summary
- replace the failing corepack usage with a direct npm upgrade in both stages of the Docker build
- ensure dependency installation succeeds without relying on corepack

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de95d97b9c832c958d5da7d99ed85b