### PR TITLE
Use corepack to activate npm in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:20-bookworm-slim AS build
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN npm install -g npm@latest \
+RUN corepack enable \
+    && corepack prepare npm@latest --activate \
     && npm ci
 
 COPY . .
@@ -14,7 +15,8 @@ FROM node:20-bookworm-slim AS base
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN npm install -g npm@latest \
+RUN corepack enable \
+    && corepack prepare npm@latest --activate \
     && npm ci --omit=dev
 
 COPY --from=build /usr/src/app/dist ./dist


### PR DESCRIPTION
## Summary
- enable Corepack in both Docker build stages
- activate the latest npm through Corepack before running npm install commands

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0587e94e8832c9f6f22a03b7c2d48