### PR TITLE
fix: install corepack before enabling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:20-bookworm-slim AS build
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN corepack enable \
+RUN npm install -g corepack \
+    && corepack enable \
     && corepack prepare npm@latest --activate \
     && npm ci
 
@@ -15,7 +16,8 @@ FROM node:20-bookworm-slim AS base
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN corepack enable \
+RUN npm install -g corepack \
+    && corepack enable \
     && corepack prepare npm@latest --activate \
     && npm ci --omit=dev
 


### PR DESCRIPTION
## Summary
- install corepack globally in both Docker stages before enabling and preparing npm

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e05bf5e478832cbd2be7baf1ca8669