### PR TITLE
Simplify Dockerfile npm setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,7 @@ FROM node:20-bookworm-slim AS build
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN npm install -g corepack \
-    && corepack enable \
-    && corepack prepare npm@latest --activate \
-    && npm ci
+RUN npm ci
 
 COPY . .
 RUN npm run distro
@@ -16,10 +13,7 @@ FROM node:20-bookworm-slim AS base
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN npm install -g corepack \
-    && corepack enable \
-    && corepack prepare npm@latest --activate \
-    && npm ci --omit=dev
+RUN npm ci --omit=dev
 
 COPY --from=build /usr/src/app/dist ./dist
 COPY --from=build /usr/src/app/assets ./assets


### PR DESCRIPTION
## Summary
- remove the custom corepack bootstrap steps from the Dockerfile and rely on the bundled npm
- keep the production installation lean with `npm ci --omit=dev`

## Testing
- npm run distro

------
https://chatgpt.com/codex/tasks/task_e_68e0621016cc832c93cf62751fe15442