### PR TITLE
Fix Docker build by reusing pruned node modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,16 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY . .
-RUN npm run distro
+RUN npm run distro \
+    && npm prune --omit=dev
 
 FROM node:20-bookworm-slim AS base
 
 WORKDIR /usr/src/app
 
-COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
-
+COPY --from=build /usr/src/app/package.json ./
+COPY --from=build /usr/src/app/package-lock.json ./
+COPY --from=build /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/dist ./dist
 COPY --from=build /usr/src/app/assets ./assets
 COPY --from=build /usr/src/app/resources ./resources


### PR DESCRIPTION
## Summary
- prune development dependencies after building the distro
- reuse the pruned node_modules from the build stage in the final image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12f53e868832c878ba9be76ff7c0d