### PR TITLE
Skip prepare script during Docker npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-bookworm-slim AS build
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 COPY . .
 RUN npm run distro \


### PR DESCRIPTION
## Summary
- prevent the prepare script from running before sources are copied during the Docker build
- keep the distro build step after the full source is available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1321fb2d0832c93b9bbcfca9d7458