### PR TITLE
Add build run version tag to Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,6 +36,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ steps.prep.outputs.image }}
+          tags: |
+            type=raw,value=build-${{ github.run_number }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
- add docker metadata tag to publish workflow so each build receives a build-number-based tag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2e5cc7778832c92aff71fa66da314