### PR TITLE
Add dev Docker image tag alongside build number

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,6 +38,7 @@ jobs:
           images: ${{ steps.prep.outputs.image }}
           tags: |
             type=raw,value=${{ github.run_number }}
+            type=raw,value=dev
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
- add the static `dev` tag alongside the build-number tag when generating Docker metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2e91e3c64832cbb347e801d79af5d