### PR TITLE
feat: refresh header icons

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -55,7 +55,7 @@
             >
               <svg aria-hidden="true" class="icon" viewBox="0 0 24 24" fill="none">
                 <path
-                  d="M12 3v12m0 0l-4-4m4 4 4-4M5 21h14"
+                  d="M12 21V9m0 0l4 4m-4-4l-4 4M5 3h14"
                   stroke="currentColor"
                   stroke-width="1.75"
                   stroke-linecap="round"
@@ -73,7 +73,7 @@
             >
               <svg aria-hidden="true" class="icon" viewBox="0 0 24 24" fill="none">
                 <path
-                  d="M12 21V9m0 0 4 4m-4-4-4 4M5 3h14"
+                  d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"
                   stroke="currentColor"
                   stroke-width="1.75"
                   stroke-linecap="round"
@@ -91,7 +91,7 @@
             >
               <svg aria-hidden="true" class="icon" viewBox="0 0 24 24" fill="none">
                 <path
-                  d="M7.5 13a4.5 4.5 0 1 1 0-9 4.5 4.5 0 0 1 0 9Zm9 11a4.5 4.5 0 1 1 0-9 4.5 4.5 0 0 1 0 9ZM7.5 8.5l9 7"
+                  d="M18 5a3 3 0 1 1-6 0 3 3 0 0 1 6 0ZM18 19a3 3 0 1 1-6 0 3 3 0 0 1 6 0ZM8 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0ZM8 12L14.5 8.5M8 12L14.5 15.5"
                   stroke="currentColor"
                   stroke-width="1.75"
                   stroke-linecap="round"
@@ -111,7 +111,7 @@
             >
               <svg aria-hidden="true" class="icon" viewBox="0 0 24 24" fill="none">
                 <path
-                  d="M3.75 6.75A1.75 1.75 0 0 1 5.5 5h13a1.75 1.75 0 0 1 1.75 1.75v12.5A1.75 1.75 0 0 1 18.5 21h-13A1.75 1.75 0 0 1 3.75 19.25V6.75ZM3 9h18"
+                  d="M3.75 8.25V6.5A2 2 0 0 1 5.75 4.5h4.1l1.8 1.8H18.5A1.75 1.75 0 0 1 20.25 8.05v9.7A1.75 1.75 0 0 1 18.5 19.5h-13A1.75 1.75 0 0 1 3.75 17.75v-9.5Z"
                   stroke="currentColor"
                   stroke-width="1.75"
                   stroke-linecap="round"


### PR DESCRIPTION
## Summary
- swap the import and export button glyphs so they match their respective actions
- update the share action to use a classic tri-node share icon
- replace the storage toggle icon with a folder outline to better reflect file browsing

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68e2eb0d62e0832caddd1e93fab0d253