### PR TITLE
Update modeler header title and viewer placeholder

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -24,7 +24,7 @@
     <div class="app">
       <header class="app-header">
         <div class="app-title">
-          <span>BPMN Modeler</span>
+          <span id="diagram-name">Untitled diagram</span>
         </div>
         <div class="action-bar">
           <div class="action-group">

--- a/client/viewer.html
+++ b/client/viewer.html
@@ -10,9 +10,7 @@
   <body class="viewer-app">
     <div class="viewer-canvas">
       <div id="viewer"></div>
-      <div id="viewer-empty" class="viewer-empty" hidden>
-        Provide a <code>?path=&lt;file.bpmn&gt;</code> query parameter to load a diagram.
-      </div>
+      <div id="viewer-empty" class="viewer-empty" hidden></div>
     </div>
     <script type="module" src="/src/viewer/main.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- replace the modeler header title placeholder with the active diagram name and keep the browser title in sync
- update diagram title whenever a file is imported, loaded, or renamed via modeling commands
- remove the viewer page hint that asked for a query parameter so the empty state stays unobtrusive

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68e2f6083594832c92f4228c85800131