### PR TITLE
Add option to share snapshots or source files

### DIFF
--- a/client/src/modeler/main.js
+++ b/client/src/modeler/main.js
@@ -346,22 +346,51 @@ async function shareCurrentDiagram() {
   shareButton.disabled = true;
 
   try {
-    const { xml } = await modeler.saveXML({ format: true });
-    const timestamp = new Date()
-      .toISOString()
-      .replace(/[:.]/g, '-');
-    const sharePath = `shared/diagram-${timestamp}.bpmn`;
+    const shouldCreateSnapshot = window.confirm(
+      'Create a new snapshot copy for sharing?\nSelect "Cancel" to share the original file instead.'
+    );
 
-    const response = await fetch('/api/storage/file', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ path: sharePath, contents: xml })
-    });
+    let sharePath;
 
-    if (!response.ok) {
-      throw new Error('Failed to store shared diagram');
+    if (shouldCreateSnapshot) {
+      const { xml } = await modeler.saveXML({ format: true });
+      const timestamp = new Date()
+        .toISOString()
+        .replace(/[:.]/g, '-');
+      sharePath = `shared/diagram-${timestamp}.bpmn`;
+
+      const response = await fetch('/api/storage/file', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ path: sharePath, contents: xml })
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to store shared diagram');
+      }
+    } else {
+      const sourcePath = savePathInput.value.trim();
+
+      if (!sourcePath) {
+        alert('Provide a file path to share the source diagram.');
+        return;
+      }
+
+      const normalizedPath = sourcePath.endsWith('.bpmn')
+        ? sourcePath
+        : `${sourcePath}.bpmn`;
+
+      const confirmDirectShare = window.confirm(
+        `The share link will point to "${normalizedPath}".\nEnsure your latest changes are saved before continuing.`
+      );
+
+      if (!confirmDirectShare) {
+        return;
+      }
+
+      sharePath = normalizedPath;
     }
 
     const shareUrl = new URL('/viewer', window.location.origin);


### PR DESCRIPTION
## Summary
- prompt the user to choose between creating a snapshot copy or linking to the stored source when sharing a diagram
- retain snapshot creation workflow and store the generated file when selected
- support direct source sharing by normalizing the path and confirming the choice with the user

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2f71f22dc832cb613d13125cbd135