### PR TITLE
Add internationalization support for modeler and viewer

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -24,7 +24,7 @@
     <div class="app">
       <header class="app-header">
         <div class="app-title">
-          <span id="diagram-name">Untitled diagram</span>
+          <span id="diagram-name" data-i18n="diagram.untitled">Untitled diagram</span>
         </div>
         <div class="action-bar">
           <div class="action-group">
@@ -32,8 +32,7 @@
               class="button icon-button primary"
               id="new-diagram"
               type="button"
-              aria-label="Create a new diagram"
-              title="Create a new diagram"
+              data-i18n-attrs="aria-label:actions.newDiagram.ariaLabel,title:actions.newDiagram.title"
             >
               <svg aria-hidden="true" class="icon" viewBox="0 0 24 24" fill="none">
                 <path
@@ -44,14 +43,13 @@
                   stroke-linejoin="round"
                 />
               </svg>
-              <span class="sr-only">New diagram</span>
+              <span class="sr-only" data-i18n="actions.newDiagram.label">New diagram</span>
             </button>
             <button
               class="button icon-button"
               id="import-file"
               type="button"
-              aria-label="Import a BPMN file"
-              title="Import a BPMN file"
+              data-i18n-attrs="aria-label:actions.importFile.ariaLabel,title:actions.importFile.title"
             >
               <svg aria-hidden="true" class="icon" viewBox="0 0 24 24" fill="none">
                 <path
@@ -62,14 +60,13 @@
                   stroke-linejoin="round"
                 />
               </svg>
-              <span class="sr-only">Import file</span>
+              <span class="sr-only" data-i18n="actions.importFile.label">Import file</span>
             </button>
             <button
               class="button icon-button"
               id="download-diagram"
               type="button"
-              aria-label="Download the current BPMN diagram"
-              title="Download the current BPMN diagram"
+              data-i18n-attrs="aria-label:actions.downloadDiagram.ariaLabel,title:actions.downloadDiagram.title"
             >
               <svg aria-hidden="true" class="icon" viewBox="0 0 24 24" fill="none">
                 <path
@@ -80,14 +77,13 @@
                   stroke-linejoin="round"
                 />
               </svg>
-              <span class="sr-only">Download diagram</span>
+              <span class="sr-only" data-i18n="actions.downloadDiagram.label">Download diagram</span>
             </button>
             <button
               class="button icon-button"
               id="share-diagram"
               type="button"
-              aria-label="Share the current diagram as a viewer link"
-              title="Share the current diagram as a viewer link"
+              data-i18n-attrs="aria-label:actions.shareDiagram.ariaLabel,title:actions.shareDiagram.title"
             >
               <svg aria-hidden="true" class="icon" viewBox="0 0 24 24" fill="none">
                 <path
@@ -98,7 +94,7 @@
                   stroke-linejoin="round"
                 />
               </svg>
-              <span class="sr-only">Share diagram</span>
+              <span class="sr-only" data-i18n="actions.shareDiagram.label">Share diagram</span>
             </button>
           </div>
           <div class="action-group">
@@ -106,8 +102,7 @@
               class="button icon-button file-browser-toggle"
               id="toggle-storage"
               type="button"
-              aria-label="Open workspace storage"
-              title="Open workspace storage"
+              data-i18n-attrs="aria-label:actions.openStorage.ariaLabel,title:actions.openStorage.title"
             >
               <svg aria-hidden="true" class="icon" viewBox="0 0 24 24" fill="none">
                 <path
@@ -118,16 +113,14 @@
                   stroke-linejoin="round"
                 />
               </svg>
-              <span class="sr-only">Open storage</span>
+              <span class="sr-only" data-i18n="actions.openStorage.label">Open storage</span>
             </button>
             <button
               class="button icon-button"
               type="button"
               id="theme-toggle"
               aria-pressed="false"
-              aria-label="Activate dark mode"
-              title="Activate dark mode"
-            >
+              >
               <svg aria-hidden="true" class="icon icon-sun" viewBox="0 0 24 24" fill="none">
                 <path
                   d="M12 5V3m0 18v-2m7-7h2M3 12h2m12.364-6.364 1.414-1.414M5.222 18.778l1.414-1.414m0-10.95-1.414-1.414m12.728 12.728-1.414-1.414M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"
@@ -146,8 +139,12 @@
                   stroke-linejoin="round"
                 />
               </svg>
-              <span class="sr-only">Toggle theme</span>
+              <span class="sr-only" data-i18n="theme.srLabel">Toggle theme</span>
             </button>
+          </div>
+          <div class="action-group language-group">
+            <label for="language-select" class="sr-only" data-i18n="language.label">Language</label>
+            <select id="language-select" class="language-select"></select>
           </div>
         </div>
       </header>
@@ -160,8 +157,8 @@
       <div id="file-browser" class="file-browser hidden" aria-hidden="true">
         <div class="file-browser-card">
           <div class="file-browser-header">
-            <h2>Workspace Storage</h2>
-            <button class="button" id="close-storage">Close</button>
+            <h2 data-i18n="storage.title">Workspace Storage</h2>
+            <button class="button" id="close-storage" data-i18n="storage.close">Close</button>
           </div>
           <div class="file-browser-body">
             <div class="tree-view" aria-live="polite">
@@ -169,24 +166,24 @@
             </div>
             <div class="file-browser-actions">
               <div class="panel-card">
-                <h3>Save Diagram</h3>
-                <p class="storage-hint">Enter a path relative to the workspace root. Create folders as needed.</p>
+                <h3 data-i18n="storage.saveHeading">Save Diagram</h3>
+                <p class="storage-hint" data-i18n="storage.saveHint">Enter a path relative to the workspace root. Create folders as needed.</p>
                 <form id="save-form">
                   <div class="input-group">
-                    <label for="save-path">File path</label>
-                    <input type="text" id="save-path" placeholder="diagrams/example.bpmn" />
+                    <label for="save-path" data-i18n="storage.savePathLabel">File path</label>
+                    <input type="text" id="save-path" data-i18n-attrs="placeholder:storage.savePlaceholder" placeholder="diagrams/example.bpmn" />
                   </div>
-                  <button type="submit" class="small-button primary">Save</button>
+                  <button type="submit" class="small-button primary" data-i18n="storage.saveButton">Save</button>
                 </form>
               </div>
               <div class="panel-card">
-                <h3>Create Folder</h3>
+                <h3 data-i18n="storage.createHeading">Create Folder</h3>
                 <form id="folder-form">
                   <div class="input-group">
-                    <label for="folder-path">Folder path</label>
-                    <input type="text" id="folder-path" placeholder="diagrams/new-folder" />
+                    <label for="folder-path" data-i18n="storage.folderPathLabel">Folder path</label>
+                    <input type="text" id="folder-path" data-i18n-attrs="placeholder:storage.folderPlaceholder" placeholder="diagrams/new-folder" />
                   </div>
-                  <button type="submit" class="small-button">Create</button>
+                  <button type="submit" class="small-button" data-i18n="storage.createButton">Create</button>
                 </form>
               </div>
             </div>
@@ -197,37 +194,37 @@
     <dialog id="share-dialog" aria-labelledby="share-dialog-title">
       <form id="share-form" class="share-dialog" method="dialog">
         <header class="share-dialog-header">
-          <h2 id="share-dialog-title">Share diagram</h2>
-          <p class="share-dialog-description">Choose how you'd like to share this diagram.</p>
+          <h2 id="share-dialog-title" data-i18n="share.dialogTitle">Share diagram</h2>
+          <p class="share-dialog-description" data-i18n="share.dialogDescription">Choose how you'd like to share this diagram.</p>
         </header>
         <fieldset class="share-options">
-          <legend>Share options</legend>
+          <legend data-i18n="share.optionsLegend">Share options</legend>
           <label class="share-option">
             <input type="radio" name="share-mode" value="source" />
             <span class="share-option-content">
-              <span class="share-option-title">Share saved source file</span>
-              <span class="share-option-hint">Generate a link to the file stored in workspace storage.</span>
+              <span class="share-option-title" data-i18n="share.sourceTitle">Share saved source file</span>
+              <span class="share-option-hint" data-i18n="share.sourceHint">Generate a link to the file stored in workspace storage.</span>
             </span>
           </label>
           <label class="share-option">
             <input type="radio" name="share-mode" value="snapshot" checked />
             <span class="share-option-content">
-              <span class="share-option-title">Create snapshot copy</span>
-              <span class="share-option-hint">Save a timestamped copy in <code>shared/</code> and share that link.</span>
+              <span class="share-option-title" data-i18n="share.snapshotTitle">Create snapshot copy</span>
+              <span class="share-option-hint" data-i18n-html="share.snapshotHint">Save a timestamped copy in <code>shared/</code> and share that link.</span>
             </span>
           </label>
         </fieldset>
         <div class="share-error" id="share-error" role="alert" aria-live="polite"></div>
         <div class="share-link-group hidden" id="share-link-group">
-          <label for="share-link">Share link</label>
+          <label for="share-link" data-i18n="share.linkLabel">Share link</label>
           <div class="share-link-row">
             <input id="share-link" type="text" readonly />
             <button type="button" class="small-button" id="copy-share-link">Copy link</button>
           </div>
         </div>
         <div class="share-actions">
-          <button type="button" class="button" id="share-cancel">Cancel</button>
-          <button type="submit" class="button primary" id="share-generate">Generate link</button>
+          <button type="button" class="button" id="share-cancel" data-i18n="share.cancel">Cancel</button>
+          <button type="submit" class="button primary" id="share-generate" data-i18n="share.generate">Generate link</button>
         </div>
       </form>
     </dialog>

--- a/client/src/i18n/index.js
+++ b/client/src/i18n/index.js
@@ -1,0 +1,368 @@
+const FALLBACK_LOCALE = 'en';
+const LANGUAGE_STORAGE_KEY = 'bpmn-language-preference';
+
+const messages = {
+  en: {
+    language: {
+      label: 'Language',
+      options: {
+        en: 'English',
+        de: 'Deutsch'
+      }
+    },
+    app: {
+      modelerTitle: 'BPMN Modeler',
+      viewerTitle: 'BPMN Viewer'
+    },
+    diagram: {
+      untitled: 'Untitled diagram',
+      unsaved: 'Unsaved diagram'
+    },
+    actions: {
+      newDiagram: {
+        label: 'New diagram',
+        ariaLabel: 'Create a new diagram',
+        title: 'Create a new diagram'
+      },
+      importFile: {
+        label: 'Import file',
+        ariaLabel: 'Import a BPMN file',
+        title: 'Import a BPMN file'
+      },
+      downloadDiagram: {
+        label: 'Download diagram',
+        ariaLabel: 'Download the current BPMN diagram',
+        title: 'Download the current BPMN diagram'
+      },
+      shareDiagram: {
+        label: 'Share diagram',
+        ariaLabel: 'Share the current diagram as a viewer link',
+        title: 'Share the current diagram as a viewer link'
+      },
+      openStorage: {
+        label: 'Open storage',
+        ariaLabel: 'Open workspace storage',
+        title: 'Open workspace storage'
+      }
+    },
+    theme: {
+      srLabel: 'Toggle theme',
+      activateDark: 'Activate dark mode',
+      activateLight: 'Activate light mode',
+      switchToDark: 'Switch to dark mode',
+      switchToLight: 'Switch to light mode',
+      followSystemHint: 'Shift + click to follow system theme'
+    },
+    storage: {
+      title: 'Workspace Storage',
+      close: 'Close',
+      saveHeading: 'Save Diagram',
+      saveHint: 'Enter a path relative to the workspace root. Create folders as needed.',
+      savePathLabel: 'File path',
+      savePlaceholder: 'diagrams/example.bpmn',
+      saveButton: 'Save',
+      createHeading: 'Create Folder',
+      folderPathLabel: 'Folder path',
+      folderPlaceholder: 'diagrams/new-folder',
+      createButton: 'Create',
+      empty: 'Storage is empty.',
+      failed: 'Failed to load storage.'
+    },
+    share: {
+      dialogTitle: 'Share diagram',
+      dialogDescription: "Choose how you'd like to share this diagram.",
+      optionsLegend: 'Share options',
+      sourceTitle: 'Share saved source file',
+      sourceHint: 'Generate a link to the file stored in workspace storage.',
+      snapshotTitle: 'Create snapshot copy',
+      snapshotHint: 'Save a timestamped copy in <code>shared/</code> and share that link.',
+      linkLabel: 'Share link',
+      copyLink: 'Copy link',
+      cancel: 'Cancel',
+      generate: 'Generate link',
+      copied: 'Copied!',
+      error: {
+        noSource: 'Save the diagram before sharing the source file.',
+        generic: 'Unable to generate a share link. Please try again.',
+        clipboardUnsupported: 'Copy to clipboard is not supported in this browser.'
+      },
+      alertUnsupported: 'Sharing is not supported in this browser.'
+    },
+    prompts: {
+      provideFilePath: 'Provide a file path to save the diagram.',
+      provideFolderPath: 'Provide a folder path.'
+    },
+    notifications: {
+      newDiagramFailed: 'Failed to create a new diagram. Check the console for details.',
+      importFailed: 'Failed to import the selected file.',
+      downloadFailed: 'Failed to download the BPMN diagram.',
+      loadFromStorageFailed: 'Unable to load the BPMN file from storage.',
+      saveSuccess: 'Diagram saved to storage.',
+      saveFailed: 'Unable to save the BPMN file.',
+      folderCreated: 'Folder created.',
+      folderCreateFailed: 'Unable to create the folder.'
+    },
+    viewer: {
+      missingPath: 'No diagram path provided. Append ?path=your/file.bpmn to the URL.',
+      loadError: 'Unable to load diagram. Check the path and try again.'
+    }
+  },
+  de: {
+    language: {
+      label: 'Sprache',
+      options: {
+        en: 'Englisch',
+        de: 'Deutsch'
+      }
+    },
+    app: {
+      modelerTitle: 'BPMN-Modeler',
+      viewerTitle: 'BPMN-Viewer'
+    },
+    diagram: {
+      untitled: 'Unbenanntes Diagramm',
+      unsaved: 'Nicht gespeichertes Diagramm'
+    },
+    actions: {
+      newDiagram: {
+        label: 'Neues Diagramm',
+        ariaLabel: 'Ein neues Diagramm erstellen',
+        title: 'Ein neues Diagramm erstellen'
+      },
+      importFile: {
+        label: 'Datei importieren',
+        ariaLabel: 'Eine BPMN-Datei importieren',
+        title: 'Eine BPMN-Datei importieren'
+      },
+      downloadDiagram: {
+        label: 'Diagramm herunterladen',
+        ariaLabel: 'Das aktuelle BPMN-Diagramm herunterladen',
+        title: 'Das aktuelle BPMN-Diagramm herunterladen'
+      },
+      shareDiagram: {
+        label: 'Diagramm teilen',
+        ariaLabel: 'Das aktuelle Diagramm als Viewer-Link teilen',
+        title: 'Das aktuelle Diagramm als Viewer-Link teilen'
+      },
+      openStorage: {
+        label: 'Speicher öffnen',
+        ariaLabel: 'Arbeitsbereichsspeicher öffnen',
+        title: 'Arbeitsbereichsspeicher öffnen'
+      }
+    },
+    theme: {
+      srLabel: 'Theme umschalten',
+      activateDark: 'Dunkelmodus aktivieren',
+      activateLight: 'Hellmodus aktivieren',
+      switchToDark: 'Zum Dunkelmodus wechseln',
+      switchToLight: 'Zum Hellmodus wechseln',
+      followSystemHint: 'Shift + Klick, um dem Systemthema zu folgen'
+    },
+    storage: {
+      title: 'Arbeitsbereichsspeicher',
+      close: 'Schließen',
+      saveHeading: 'Diagramm speichern',
+      saveHint: 'Geben Sie einen Pfad relativ zum Arbeitsbereich an. Erstellen Sie bei Bedarf Ordner.',
+      savePathLabel: 'Dateipfad',
+      savePlaceholder: 'diagramme/beispiel.bpmn',
+      saveButton: 'Speichern',
+      createHeading: 'Ordner erstellen',
+      folderPathLabel: 'Ordnerpfad',
+      folderPlaceholder: 'diagramme/neuer-ordner',
+      createButton: 'Erstellen',
+      empty: 'Der Speicher ist leer.',
+      failed: 'Speicher konnte nicht geladen werden.'
+    },
+    share: {
+      dialogTitle: 'Diagramm teilen',
+      dialogDescription: 'Wählen Sie aus, wie Sie dieses Diagramm teilen möchten.',
+      optionsLegend: 'Teiloptionen',
+      sourceTitle: 'Gespeicherte Quelldatei teilen',
+      sourceHint: 'Einen Link zur im Arbeitsbereich gespeicherten Datei erzeugen.',
+      snapshotTitle: 'Schnappschusskopie erstellen',
+      snapshotHint: 'Eine Version mit Zeitstempel in <code>shared/</code> speichern und diesen Link teilen.',
+      linkLabel: 'Teil-Link',
+      copyLink: 'Link kopieren',
+      cancel: 'Abbrechen',
+      generate: 'Link erzeugen',
+      copied: 'Kopiert!',
+      error: {
+        noSource: 'Speichern Sie das Diagramm, bevor Sie die Quelldatei teilen.',
+        generic: 'Teil-Link konnte nicht erzeugt werden. Bitte erneut versuchen.',
+        clipboardUnsupported: 'Zwischenablage wird in diesem Browser nicht unterstützt.'
+      },
+      alertUnsupported: 'Teilen wird in diesem Browser nicht unterstützt.'
+    },
+    prompts: {
+      provideFilePath: 'Geben Sie einen Dateipfad zum Speichern des Diagramms an.',
+      provideFolderPath: 'Geben Sie einen Ordnerpfad an.'
+    },
+    notifications: {
+      newDiagramFailed: 'Neues Diagramm konnte nicht erstellt werden. Details siehe Konsole.',
+      importFailed: 'Ausgewählte Datei konnte nicht importiert werden.',
+      downloadFailed: 'BPMN-Diagramm konnte nicht heruntergeladen werden.',
+      loadFromStorageFailed: 'BPMN-Datei konnte nicht aus dem Speicher geladen werden.',
+      saveSuccess: 'Diagramm im Speicher abgelegt.',
+      saveFailed: 'BPMN-Datei konnte nicht gespeichert werden.',
+      folderCreated: 'Ordner erstellt.',
+      folderCreateFailed: 'Ordner konnte nicht erstellt werden.'
+    },
+    viewer: {
+      missingPath: 'Kein Diagrammpfad angegeben. Hängen Sie ?path=pfad/zur/datei.bpmn an die URL an.',
+      loadError: 'Diagramm konnte nicht geladen werden. Pfad überprüfen und erneut versuchen.'
+    }
+  }
+};
+
+let currentLocale = FALLBACK_LOCALE;
+const listeners = new Set();
+
+function getMessage(locale, key) {
+  const segments = key.split('.');
+  let value = messages[locale];
+
+  for (const segment of segments) {
+    if (value && typeof value === 'object' && segment in value) {
+      value = value[segment];
+    } else {
+      return undefined;
+    }
+  }
+
+  return typeof value === 'string' ? value : undefined;
+}
+
+function readStoredLocale() {
+  try {
+    return localStorage.getItem(LANGUAGE_STORAGE_KEY) || undefined;
+  } catch (error) {
+    console.warn('Unable to read locale from storage.', error);
+    return undefined;
+  }
+}
+
+function persistLocale(locale) {
+  try {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, locale);
+  } catch (error) {
+    console.warn('Unable to persist locale preference.', error);
+  }
+}
+
+function normalizeLocale(locale) {
+  if (locale && locale in messages) {
+    return locale;
+  }
+
+  return FALLBACK_LOCALE;
+}
+
+function detectLocale() {
+  const stored = readStoredLocale();
+
+  if (stored && stored in messages) {
+    return stored;
+  }
+
+  const navigatorLocale = typeof navigator !== 'undefined' ? navigator.language?.split('-')[0]?.toLowerCase() : undefined;
+
+  if (navigatorLocale && navigatorLocale in messages) {
+    return navigatorLocale;
+  }
+
+  return FALLBACK_LOCALE;
+}
+
+function notifyLocaleChange() {
+  document.documentElement.setAttribute('lang', currentLocale);
+  listeners.forEach((listener) => listener(currentLocale));
+}
+
+export function setLocale(locale) {
+  const normalized = normalizeLocale(locale);
+
+  if (normalized === currentLocale) {
+    document.documentElement.setAttribute('lang', currentLocale);
+    return;
+  }
+
+  currentLocale = normalized;
+  persistLocale(normalized);
+  notifyLocaleChange();
+}
+
+export function initializeLocale() {
+  const initialLocale = detectLocale();
+  currentLocale = initialLocale;
+  document.documentElement.setAttribute('lang', currentLocale);
+  persistLocale(currentLocale);
+  notifyLocaleChange();
+  return currentLocale;
+}
+
+export function t(key) {
+  return getMessage(currentLocale, key) ?? getMessage(FALLBACK_LOCALE, key) ?? key;
+}
+
+export function onLocaleChange(listener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getCurrentLocale() {
+  return currentLocale;
+}
+
+export function getAvailableLocales() {
+  return Object.keys(messages);
+}
+
+export function applyTranslations(root = document) {
+  const textElements = root.querySelectorAll('[data-i18n]');
+  textElements.forEach((element) => {
+    const key = element.dataset.i18n;
+    if (!key) {
+      return;
+    }
+
+    const translation = t(key);
+    if (translation !== undefined) {
+      element.textContent = translation;
+    }
+  });
+
+  const htmlElements = root.querySelectorAll('[data-i18n-html]');
+  htmlElements.forEach((element) => {
+    const key = element.dataset.i18nHtml;
+    if (!key) {
+      return;
+    }
+
+    const translation = t(key);
+    if (translation !== undefined) {
+      element.innerHTML = translation;
+    }
+  });
+
+  const attrElements = root.querySelectorAll('[data-i18n-attrs]');
+  attrElements.forEach((element) => {
+    const config = element.dataset.i18nAttrs;
+    if (!config) {
+      return;
+    }
+
+    const pairs = config.split(',');
+
+    pairs.forEach((pair) => {
+      const [attr, key] = pair.split(':').map((part) => part.trim());
+      if (!attr || !key) {
+        return;
+      }
+
+      const translation = t(key);
+      if (translation !== undefined) {
+        element.setAttribute(attr, translation);
+      }
+    });
+  });
+}

--- a/client/src/modeler/style.css
+++ b/client/src/modeler/style.css
@@ -45,6 +45,31 @@
   gap: 0.5rem;
 }
 
+.language-group {
+  align-items: center;
+}
+
+.language-select {
+  padding: 0.45rem 1.5rem 0.45rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: var(--button-bg);
+  color: var(--button-text);
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.35s ease, color 0.35s ease, border-color 0.35s ease, box-shadow 0.15s ease;
+}
+
+.language-select:hover {
+  box-shadow: var(--button-hover-shadow);
+}
+
+.language-select:focus-visible {
+  outline: none;
+  box-shadow: var(--button-primary-shadow);
+}
+
 .button {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add a shared i18n utility with English and German locales
- translate modeler UI strings and expose a language selector
- localize the viewer experience and ensure titles/messages react to locale changes

## Testing
- npm run build *(fails: vite executable not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ff8f1994832c9bee222f495d727b