### PR TITLE
Ensure diagram URL parameter includes folder path

### DIFF
--- a/client/src/modeler/main.js
+++ b/client/src/modeler/main.js
@@ -214,6 +214,26 @@ function updateDiagramTitle() {
 }
 
 function getDiagramUrlIdentifier() {
+  if (currentStoragePath?.trim()) {
+    const normalizedPath = normalizeStoragePath(currentStoragePath).trim();
+
+    if (normalizedPath) {
+      const segments = normalizedPath.split('/');
+      const fileName = segments.pop();
+      const sanitizedFileName = normalizeDiagramName(fileName) || fileName?.trim();
+
+      if (sanitizedFileName) {
+        segments.push(sanitizedFileName);
+      }
+
+      const identifier = segments.filter(Boolean).join('/');
+
+      if (identifier) {
+        return identifier;
+      }
+    }
+  }
+
   if (currentDiagramName?.trim()) {
     return currentDiagramName.trim();
   }


### PR DESCRIPTION
## Summary
- include the storage folder path when generating the diagram query parameter
- keep the diagram URL identifiers unique across folders to avoid collisions

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68e307f359e0832c840a93c1220d7e43