### PR TITLE
Hide BPMN.io watermark in modeler and viewer

### DIFF
--- a/client/src/modeler/style.css
+++ b/client/src/modeler/style.css
@@ -123,6 +123,10 @@
   height: 100%;
 }
 
+.bjs-powered-by {
+  display: none !important;
+}
+
 .properties-panel-parent {
   width: 340px;
   background: var(--panel-bg);

--- a/client/src/viewer/style.css
+++ b/client/src/viewer/style.css
@@ -16,6 +16,10 @@
   height: 100%;
 }
 
+.bjs-powered-by {
+  display: none !important;
+}
+
 .viewer-empty {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- hide the BPMN.io watermark overlay in the modeler canvas styling
- remove the BPMN.io watermark from the viewer to keep the interface clean

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e30907bcc4832c911ba97b91a44703