### PR TITLE
Fix loading diagrams from folders on reload

### DIFF
--- a/client/src/modeler/main.js
+++ b/client/src/modeler/main.js
@@ -704,9 +704,13 @@ async function loadDiagramFromStorage(path) {
     if (savePathInput) {
       savePathInput.value = normalizedPath;
     }
+
+    return true;
   } catch (error) {
     console.error(error);
     alert(t('notifications.loadFromStorageFailed'));
+
+    return false;
   }
 }
 
@@ -906,4 +910,28 @@ folderForm?.addEventListener('submit', async (event) => {
   folderPathInput.value = '';
 });
 
-createNewDiagram();
+async function initializeDiagram() {
+  const params = new URLSearchParams(window.location.search);
+  const identifier = params.get('diagram');
+
+  if (!identifier || identifier === 'new') {
+    await createNewDiagram();
+    return;
+  }
+
+  const normalizedIdentifier = normalizeStoragePath(identifier).trim();
+
+  if (!normalizedIdentifier) {
+    await createNewDiagram();
+    return;
+  }
+
+  const candidatePath = ensureBpmnExtension(normalizedIdentifier);
+  const loaded = await loadDiagramFromStorage(candidatePath);
+
+  if (!loaded) {
+    await createNewDiagram();
+  }
+}
+
+void initializeDiagram();


### PR DESCRIPTION
## Summary
- return a status from the storage loader so callers can detect failures
- load the current diagram from the URL query parameter on startup, including nested paths
- fall back to the default blank diagram when no stored file can be loaded

## Testing
- npm run build:client *(fails: vite not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e30be61e48832ca04ec4a1f4f9cccc