### PR TITLE
Update Docker publish workflow for main branch tagging

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Build and Publish Docker Image
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["dev", "main"]
   release:
     types: [published]
   workflow_dispatch:
@@ -31,6 +31,15 @@ jobs:
           image="ghcr.io/${GITHUB_REPOSITORY,,}"
           echo "image=$image" >> "$GITHUB_OUTPUT"
 
+      - name: Determine branch tag
+        id: branch_tag
+        run: |
+          if [ "${GITHUB_REF}" = "refs/heads/main" ] || [ "${GITHUB_EVENT_NAME}" = "release" ]; then
+            echo "branch_tag=type=raw,value=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch_tag=type=raw,value=dev" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -38,7 +47,7 @@ jobs:
           images: ${{ steps.prep.outputs.image }}
           tags: |
             type=raw,value=${{ github.run_number }}
-            type=raw,value=dev
+            ${{ steps.branch_tag.outputs.branch_tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
- trigger the Docker publish workflow on pushes to both dev and main
- derive the Docker image tag dynamically so main (and releases) use `latest` while dev keeps the `dev` tag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e38b2e8728832cbd33767104d9b200