### PR TITLE
feat: add toolbar save button

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -83,6 +83,37 @@
             </button>
             <button
               class="button icon-button"
+              id="save-diagram"
+              type="button"
+              data-i18n-attrs="aria-label:actions.saveDiagram.ariaLabel,title:actions.saveDiagram.title"
+            >
+              <svg aria-hidden="true" class="icon" viewBox="0 0 24 24" fill="none">
+                <path
+                  d="M5 4a2 2 0 0 1 2-2h9.172a2 2 0 0 1 1.414.586l3.828 3.828A2 2 0 0 1 22 7.828V20a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M15 2v6H7V4a2 2 0 0 1 2-2Z"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M8 20h8v-5H8Z"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <span class="sr-only" data-i18n="actions.saveDiagram.label">Save diagram</span>
+            </button>
+            <button
+              class="button icon-button"
               id="share-diagram"
               type="button"
               data-i18n-attrs="aria-label:actions.shareDiagram.ariaLabel,title:actions.shareDiagram.title"

--- a/client/src/i18n/index.js
+++ b/client/src/i18n/index.js
@@ -34,6 +34,13 @@ const messages = {
         ariaLabel: 'Download the current BPMN diagram',
         title: 'Download the current BPMN diagram'
       },
+      saveDiagram: {
+        label: 'Save diagram',
+        ariaLabel: 'Save the current diagram to storage',
+        ariaLabelUnsaved: 'Choose where to save the current diagram',
+        title: 'Save the current diagram to storage',
+        titleUnsaved: 'Choose where to save the current diagram'
+      },
       shareDiagram: {
         label: 'Share diagram',
         ariaLabel: 'Share the current diagram as a viewer link',
@@ -138,6 +145,13 @@ const messages = {
         label: 'Diagramm herunterladen',
         ariaLabel: 'Das aktuelle BPMN-Diagramm herunterladen',
         title: 'Das aktuelle BPMN-Diagramm herunterladen'
+      },
+      saveDiagram: {
+        label: 'Diagramm speichern',
+        ariaLabel: 'Das aktuelle Diagramm im Speicher sichern',
+        ariaLabelUnsaved: 'Speicherort zum Speichern des Diagramms auswählen',
+        title: 'Das aktuelle Diagramm im Speicher sichern',
+        titleUnsaved: 'Speicherort zum Speichern des Diagramms auswählen'
       },
       shareDiagram: {
         label: 'Diagramm teilen',

--- a/client/src/modeler/main.js
+++ b/client/src/modeler/main.js
@@ -43,6 +43,7 @@ const modeler = new BpmnModeler({
 const newDiagramButton = document.getElementById('new-diagram');
 const importButton = document.getElementById('import-file');
 const downloadButton = document.getElementById('download-diagram');
+const saveButton = document.getElementById('save-diagram');
 const shareButton = document.getElementById('share-diagram');
 const storageToggle = document.getElementById('toggle-storage');
 const fileBrowser = document.getElementById('file-browser');
@@ -180,6 +181,7 @@ function setDiagramSource(path, fallbackName = '') {
   updateShareModeAvailability();
   updateDiagramTitle();
   updateModelerUrl();
+  updateSaveButtonState();
 }
 
 function getDiagramDisplayName() {
@@ -603,6 +605,31 @@ function renderStorageMessage(key, className) {
   storageTree.appendChild(messageItem);
 }
 
+function focusSavePathInput() {
+  if (!savePathInput) {
+    return;
+  }
+
+  requestAnimationFrame(() => {
+    savePathInput.focus();
+    savePathInput.select();
+  });
+}
+
+function updateSaveButtonState() {
+  if (!saveButton) {
+    return;
+  }
+
+  const hasStoragePath = Boolean(currentStoragePath);
+  const ariaLabelKey = hasStoragePath ? 'actions.saveDiagram.ariaLabel' : 'actions.saveDiagram.ariaLabelUnsaved';
+  const titleKey = hasStoragePath ? 'actions.saveDiagram.title' : 'actions.saveDiagram.titleUnsaved';
+
+  saveButton.dataset.mode = hasStoragePath ? 'save' : 'save-as';
+  saveButton.setAttribute('aria-label', t(ariaLabelKey));
+  saveButton.setAttribute('title', t(titleKey));
+}
+
 function populateLanguageSelect() {
   if (!languageSelect) {
     return;
@@ -633,6 +660,7 @@ function handleLocaleUpdate() {
   updateThemeToggle(currentTheme);
   updateDiagramTitle();
   updateCopyShareLinkLabel();
+  updateSaveButtonState();
 }
 
 function createTreeNode(node) {
@@ -821,6 +849,16 @@ downloadButton?.addEventListener('click', async () => {
     console.error(error);
     alert(t('notifications.downloadFailed'));
   }
+});
+
+saveButton?.addEventListener('click', async () => {
+  if (currentStoragePath) {
+    await saveDiagramToStorage(ensureBpmnExtension(currentStoragePath));
+    return;
+  }
+
+  toggleStorageOverlay(true);
+  focusSavePathInput();
 });
 
 shareButton?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add a toolbar save button that appears next to the download action
- adjust i18n resources to describe the new save interaction in English and German
- update modeler logic to reuse the existing storage path or open the storage overlay when saving

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e50a249f3c832cab2916070f0db685