### PR TITLE
Add XML editor dialog and zoom controls

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -83,6 +83,37 @@
             </button>
             <button
               class="button icon-button"
+              id="edit-xml"
+              type="button"
+              data-i18n-attrs="aria-label:actions.editXml.ariaLabel,title:actions.editXml.title"
+            >
+              <svg aria-hidden="true" class="icon" viewBox="0 0 24 24" fill="none">
+                <path
+                  d="M4 5a2 2 0 0 1 2-2h6l4 4v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2Z"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M14 3v4h4"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M9 13h6M9 17h6M9 9h2"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <span class="sr-only" data-i18n="actions.editXml.label">Edit XML</span>
+            </button>
+            <button
+              class="button icon-button"
               id="save-diagram"
               type="button"
               data-i18n-attrs="aria-label:actions.saveDiagram.ariaLabel,title:actions.saveDiagram.title"
@@ -184,6 +215,71 @@
       <div class="app-body">
         <div class="canvas-wrapper">
           <div id="canvas"></div>
+          <div
+            class="zoom-controls"
+            role="group"
+            aria-label="Zoom controls"
+            data-i18n-attrs="aria-label:zoom.groupLabel"
+          >
+            <button
+              class="zoom-button"
+              type="button"
+              id="zoom-in"
+              data-i18n-attrs="aria-label:zoom.in,title:zoom.in"
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                <path
+                  d="M12 5v14M5 12h14"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <span class="sr-only" data-i18n="zoom.in">Zoom in</span>
+            </button>
+            <button
+              class="zoom-button"
+              type="button"
+              id="zoom-reset"
+              data-i18n-attrs="aria-label:zoom.reset,title:zoom.reset"
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                <path
+                  d="M4 4v6h6"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M5.5 18.5A9 9 0 1 0 7 7"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <span class="sr-only" data-i18n="zoom.reset">Reset zoom</span>
+            </button>
+            <button
+              class="zoom-button"
+              type="button"
+              id="zoom-out"
+              data-i18n-attrs="aria-label:zoom.out,title:zoom.out"
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                <path
+                  d="M5 12h14"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <span class="sr-only" data-i18n="zoom.out">Zoom out</span>
+            </button>
+          </div>
         </div>
       </div>
       <div id="file-browser" class="file-browser hidden" aria-hidden="true">
@@ -223,6 +319,23 @@
         </div>
       </div>
     </div>
+    <dialog id="xml-editor-dialog" aria-labelledby="xml-editor-title">
+      <form id="xml-editor-form" class="xml-editor" method="dialog">
+        <header class="xml-editor-header">
+          <h2 id="xml-editor-title" data-i18n="xmlEditor.title">Edit XML</h2>
+          <p data-i18n="xmlEditor.description">Make changes to the BPMN XML. Invalid XML cannot be imported.</p>
+        </header>
+        <div class="xml-editor-body">
+          <label for="xml-editor-textarea" data-i18n="xmlEditor.label">Diagram XML</label>
+          <textarea id="xml-editor-textarea" class="xml-editor-textarea" spellcheck="false"></textarea>
+        </div>
+        <div class="xml-editor-error" id="xml-editor-error" role="alert" aria-live="polite"></div>
+        <div class="xml-editor-actions">
+          <button type="button" class="button" id="xml-editor-cancel" data-i18n="xmlEditor.cancel">Cancel</button>
+          <button type="submit" class="button primary" data-i18n="xmlEditor.apply">Apply changes</button>
+        </div>
+      </form>
+    </dialog>
     <dialog id="share-dialog" aria-labelledby="share-dialog-title">
       <form id="share-form" class="share-dialog" method="dialog">
         <header class="share-dialog-header">

--- a/client/src/i18n/index.js
+++ b/client/src/i18n/index.js
@@ -34,6 +34,11 @@ const messages = {
         ariaLabel: 'Download the current BPMN diagram',
         title: 'Download the current BPMN diagram'
       },
+      editXml: {
+        label: 'Edit XML',
+        ariaLabel: 'Open the XML source editor',
+        title: 'Open the XML source editor'
+      },
       saveDiagram: {
         label: 'Save diagram',
         ariaLabel: 'Save the current diagram to storage',
@@ -95,6 +100,21 @@ const messages = {
       },
       alertUnsupported: 'Sharing is not supported in this browser.'
     },
+    xmlEditor: {
+      title: 'Edit XML',
+      description: 'Make changes to the BPMN XML. Invalid XML cannot be imported.',
+      label: 'Diagram XML',
+      apply: 'Apply changes',
+      cancel: 'Cancel',
+      loadError: 'Unable to load the XML source. Please try again.',
+      importError: 'The XML is invalid. Please fix the issues and try again.'
+    },
+    zoom: {
+      groupLabel: 'Zoom controls',
+      in: 'Zoom in',
+      reset: 'Reset zoom',
+      out: 'Zoom out'
+    },
     prompts: {
       provideFilePath: 'Provide a file path to save the diagram.',
       provideFolderPath: 'Provide a folder path.'
@@ -145,6 +165,11 @@ const messages = {
         label: 'Diagramm herunterladen',
         ariaLabel: 'Das aktuelle BPMN-Diagramm herunterladen',
         title: 'Das aktuelle BPMN-Diagramm herunterladen'
+      },
+      editXml: {
+        label: 'XML bearbeiten',
+        ariaLabel: 'XML-Quelltext-Editor öffnen',
+        title: 'XML-Quelltext-Editor öffnen'
       },
       saveDiagram: {
         label: 'Diagramm speichern',
@@ -206,6 +231,21 @@ const messages = {
         clipboardUnsupported: 'Zwischenablage wird in diesem Browser nicht unterstützt.'
       },
       alertUnsupported: 'Teilen wird in diesem Browser nicht unterstützt.'
+    },
+    xmlEditor: {
+      title: 'XML bearbeiten',
+      description: 'Bearbeiten Sie den BPMN-XML-Quelltext. Ungültiges XML kann nicht importiert werden.',
+      label: 'Diagramm-XML',
+      apply: 'Änderungen anwenden',
+      cancel: 'Abbrechen',
+      loadError: 'XML-Quelltext konnte nicht geladen werden. Bitte erneut versuchen.',
+      importError: 'Das XML ist ungültig. Bitte korrigieren und erneut versuchen.'
+    },
+    zoom: {
+      groupLabel: 'Zoomsteuerung',
+      in: 'Heranzoomen',
+      reset: 'Zoom zurücksetzen',
+      out: 'Herauszoomen'
     },
     prompts: {
       provideFilePath: 'Geben Sie einen Dateipfad zum Speichern des Diagramms an.',

--- a/client/src/modeler/style.css
+++ b/client/src/modeler/style.css
@@ -143,6 +143,45 @@
   transition: background 0.35s ease;
 }
 
+.zoom-controls {
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 5;
+}
+
+.zoom-button {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: var(--button-bg);
+  color: var(--button-text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.35s ease, color 0.35s ease;
+}
+
+.zoom-button:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--button-hover-shadow);
+}
+
+.zoom-button:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.zoom-button svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
 #canvas {
   width: 100%;
   height: 100%;
@@ -294,7 +333,7 @@
   border: 1px solid var(--input-border);
   font-size: 0.95rem;
   font-family: inherit;
-  background: transparent;
+  background: var(--input-bg);
   color: inherit;
   transition: border-color 0.35s ease, background 0.35s ease, color 0.35s ease;
 }
@@ -356,6 +395,71 @@ dialog::backdrop {
 
 .share-dialog.is-processing {
   opacity: 0.8;
+}
+
+.xml-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.75rem;
+}
+
+.xml-editor-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.xml-editor-header h2 {
+  margin: 0;
+}
+
+.xml-editor-header p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--storage-hint);
+  line-height: 1.5;
+  transition: color 0.35s ease;
+}
+
+.xml-editor-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.xml-editor-body label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--input-label);
+  transition: color 0.35s ease;
+}
+
+.xml-editor-textarea {
+  width: 100%;
+  min-height: 18rem;
+  font-family: 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  padding: 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--input-border);
+  background: var(--input-bg);
+  color: inherit;
+  resize: vertical;
+  transition: border-color 0.35s ease, background 0.35s ease, color 0.35s ease;
+}
+
+.xml-editor-error {
+  color: var(--color-danger);
+  font-size: 0.9rem;
+  min-height: 1.25rem;
+}
+
+.xml-editor-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
 }
 
 .share-dialog-header h2 {
@@ -455,8 +559,9 @@ dialog::backdrop {
   border: 1px solid var(--input-border);
   font-size: 0.95rem;
   font-family: inherit;
-  background: transparent;
+  background: var(--input-bg);
   color: inherit;
+  transition: border-color 0.35s ease, background 0.35s ease, color 0.35s ease;
 }
 
 .share-actions {

--- a/client/styles/global.css
+++ b/client/styles/global.css
@@ -28,6 +28,7 @@
   --tree-hover: rgba(99, 102, 241, 0.1);
   --input-label: rgba(15, 23, 42, 0.75);
   --input-border: rgba(15, 23, 42, 0.15);
+  --input-bg: rgba(255, 255, 255, 0.9);
   --small-button-bg: #e2e8f0;
   --small-button-text: #0f172a;
   --storage-hint: rgba(15, 23, 42, 0.6);
@@ -56,6 +57,7 @@
   --tree-hover: rgba(99, 102, 241, 0.18);
   --input-label: rgba(226, 232, 240, 0.75);
   --input-border: rgba(148, 163, 184, 0.3);
+  --input-bg: rgba(15, 23, 42, 0.75);
   --small-button-bg: rgba(51, 65, 85, 0.9);
   --small-button-text: #e2e8f0;
   --storage-hint: rgba(226, 232, 240, 0.7);


### PR DESCRIPTION
## Summary
- add a toolbar action to open an XML editor dialog with validation and translations
- introduce canvas zoom controls styled to match the UI and localized labels
- adjust input backgrounds for dark mode and update related styles and translations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6cd6082f0832c917d45cda690a485